### PR TITLE
Add configurable gacha/capsule machine NPC script

### DIFF
--- a/.claude/hooks/session-status.sh
+++ b/.claude/hooks/session-status.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SessionStart hook: report repo state vs rAthena upstream.
+# Output is shown to Claude as system context. Keep it short.
+set -e
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+echo "[rAthena 私服 session] branch=${branch}"
+
+if git remote get-url upstream >/dev/null 2>&1; then
+  # Upstream is configured. Show local position vs cached upstream/master
+  # without fetching (fetch is what /sync-upstream is for; keep hook fast).
+  if git rev-parse --verify upstream/master >/dev/null 2>&1; then
+    ahead=$(git rev-list --count upstream/master..HEAD 2>/dev/null || echo "?")
+    behind=$(git rev-list --count HEAD..upstream/master 2>/dev/null || echo "?")
+    echo "vs upstream/master: ahead=${ahead} behind=${behind} (cached, run /sync-upstream to refresh)"
+  else
+    echo "upstream remote configured but upstream/master not fetched yet — run /sync-upstream"
+  fi
+else
+  echo "upstream remote not configured. Phase B will add: git remote add upstream https://github.com/rathena/rathena.git"
+fi
+
+# Discipline reminder
+echo "Reminder: never edit src/, conf/*.conf (except conf/import/), db/(re|pre-re)/, npc/(re|pre-re)/. See CLAUDE.md."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-status.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sync-upstream
+description: Fetch the latest rAthena upstream and report what changed. Use when the user wants to pull in upstream updates or check how far behind we are. Reports ahead/behind counts, lists conflicting paths in protected directories, and proposes a merge strategy without executing destructive operations.
+---
+
+# Sync rAthena upstream
+
+Goal: keep this fork close to `rathena/rathena` master without touching its files. Per `CLAUDE.md`, all customisation lives in overlay points (`npc/custom/`, `conf/import/`, `db/import/`, `sql-files/migrations/`, `data-overlay/`). Upstream paths must never be modified locally.
+
+## Steps
+
+1. **Verify upstream remote**
+   - `git remote get-url upstream` — if missing, instruct the user we're still in Phase A and that Phase B will add it via `git remote add upstream https://github.com/rathena/rathena.git`. Stop here.
+
+2. **Fetch upstream**
+   - `git fetch upstream master --tags`
+
+3. **Report position**
+   - `git rev-list --left-right --count HEAD...upstream/master` to get ahead/behind.
+   - `git log --oneline HEAD..upstream/master | head -20` for what's incoming.
+
+4. **Audit for protected-path local edits**
+   - Run `git diff --name-only $(git merge-base HEAD upstream/master) HEAD` and flag any path under: `src/`, `conf/` (excluding `conf/import/`), `db/re/`, `db/pre-re/`, `npc/re/`, `npc/pre-re/`, `sql-files/*.sql` (excluding `sql-files/migrations/`).
+   - If anything is flagged, this means the discipline was broken in a previous session. Surface it to the user before proceeding — do not silently merge.
+
+5. **Propose merge strategy** (do not execute without user confirmation)
+   - If `ahead == 0`: fast-forward — `git merge --ff-only upstream/master`.
+   - If `ahead > 0` and customisations are only in overlay points: regular merge or rebase, expect zero conflicts.
+   - If protected-path edits exist: stop, report which files, ask user how to reconcile.
+
+6. **Post-merge sanity (only if user approves merge)**
+   - `cmake -S . -B build` (or whatever build is configured) to verify it still compiles.
+   - Reload-script smoke test if the user has a running map-server.
+
+## Output format
+Always return:
+- One-line summary: `ahead=N behind=M, protected-path edits=X`
+- Incoming commits (truncated to 20)
+- Proposed action (do not execute without explicit confirmation)
+- Any discipline violations found
+
+## What this skill must NOT do
+- Never run `git reset --hard`, `git push --force`, or rewrite history.
+- Never edit files under protected paths to resolve conflicts — fix the overlay instead.
+- Never bypass hooks or signing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# Project: rAthena 中文私服客製
+
+這是一個基於 rAthena 的私服專案，目標：
+1. 跟著 rAthena 上游持續同步
+2. 中文化（最終靠 client `iteminfo.lub` + server `db/import/`）
+3. 加入自營便利功能（轉蛋、商城、活動等）
+4. 客製不與上游衝突，方便長期維護
+
+## 紀律（Claude 必須遵守）
+
+### 永不修改 upstream 對應的檔案
+以下路徑屬於 rAthena 上游，**任何 session 都不要直接編輯**：
+- `src/`
+- `conf/*.conf`（不含 `conf/import/`）
+- `db/(re|pre-re)/`（不含 `db/import/`）
+- `npc/(re|pre-re)/`、`npc/airships`、`npc/battleground`、`npc/cashshop`、`npc/event`、`npc/guild`、`npc/instances`、`npc/jobs`、`npc/kafras`、`npc/merchants`、`npc/mobs`、`npc/other`、`npc/quests`、`npc/woe-fe`、`npc/woe-se`、`npc/woe-te`
+- `sql-files/*.sql`（不含 `sql-files/migrations/`，若已建立）
+
+### 客製只能進這些位置
+- `npc/custom/`、`npc/scripts_custom.conf`（rAthena 設計給客製用）
+- `conf/import/`（覆蓋 conf 用）
+- `db/import/`（覆蓋 db YAML 用）
+- `sql-files/migrations/`（自建，本專案的 schema 變更）
+- `data-overlay/`（自建，client lub/grf 來源檔）
+
+如果上游沒提供 import 點，需要修改原始檔才能達成目的，**先停下來跟使用者確認**，不要擅自動上游檔。
+
+## 編碼規則
+- NPC `.txt`、`.conf`：UTF-8 **無 BOM**（純 rAthena 對 BOM 不友善）
+- SQL：utf8mb4 + utf8mb4_unicode_ci
+- 客戶端 `iteminfo.lub` 的 `*ResourceName` 欄位是韓文 EUC-KR，**永不轉碼**
+
+## Git 工作流
+- `master` / `main` 分支：永遠等於 upstream，不寫客製
+- 客製活在 `claude/*` 或 `feat/*` 分支
+- 提交前先跑 `/sync-upstream`（見 `.claude/skills/sync-upstream/`）確認與上游關係
+
+## 學「方案」不抄「程式碼」
+參考 Pandas / rAthenaCN 的功能設計，但不複製其 GPL-3 程式碼。能用 rAthena 原生 script + atcommand + 設定覆蓋達成的，就不要改 C++ 原始碼。

--- a/npc/custom/etc/gacha.txt
+++ b/npc/custom/etc/gacha.txt
@@ -1,0 +1,163 @@
+//===== rAthena Script =======================================
+//= Custom Gacha (轉蛋)
+//===== Description: =========================================
+//= A configurable gacha / capsule machine.
+//= - Pay with Zeny or a custom ticket item.
+//= - Three weighted prize tiers (Rare / Rare / Common).
+//= - Picks a random item from each tier's pool.
+//= - Optional broadcast when a top-tier prize is won.
+//= - Supports single pull or 10-pull (with a small bonus).
+//===== How to configure =====================================
+//= 1. Edit the .config block in OnInit below to set the
+//    currency, ticket item id, prize pools and weights.
+//= 2. Enable the script in npc/scripts_custom.conf:
+//      npc: npc/custom/etc/gacha.txt
+//= 3. Reload with @reloadscript or restart the map-server.
+//============================================================
+
+prontera,156,180,4	script	Gacha Machine#cgacha	76,{
+
+	// -- Greeting --
+	mes "[轉蛋機]";
+	mes "歡迎光臨！";
+	mes "每次轉蛋費用：^0055FF" + ((.use_item)? .ticket_amount + " 個 " + getitemname(.ticket_id) : F_InsertComma(.price) + " Zeny") + "^000000";
+	mes "10 連抽：^0055FF" + ((.use_item)? (.ticket_amount * 10) + " 個 " + getitemname(.ticket_id) : F_InsertComma(.price * 10) + " Zeny") + "^000000 (保證至少 1 個稀有獎)";
+	next;
+
+	switch (select("單抽 (1 次):10 連抽:查看獎項機率:離開")) {
+	case 1:
+		.@pulls = 1;
+		break;
+	case 2:
+		.@pulls = 10;
+		break;
+	case 3:
+		mes "[轉蛋機]";
+		mes "獎項機率：";
+		mes " - ^FF0000高級獎^000000：" + (.w_top * 100 / .w_total) + "%";
+		mes " - ^0055FF中級獎^000000：" + (.w_mid * 100 / .w_total) + "%";
+		mes " - ^777777普通獎^000000：" + (.w_low * 100 / .w_total) + "%";
+		close;
+	default:
+		close;
+	}
+
+	// -- Cost check & deduct --
+	if (.use_item) {
+		if (countitem(.ticket_id) < .ticket_amount * .@pulls) {
+			mes "[轉蛋機]";
+			mes "您的 " + getitemname(.ticket_id) + " 數量不足。";
+			close;
+		}
+		delitem .ticket_id, .ticket_amount * .@pulls;
+	} else {
+		if (Zeny < .price * .@pulls) {
+			mes "[轉蛋機]";
+			mes "您的 Zeny 不足。";
+			close;
+		}
+		Zeny -= .price * .@pulls;
+	}
+
+	// -- Roll --
+	.@guaranteed_rare = (.@pulls >= 10)? 1 : 0;
+	.@got_rare = 0;
+
+	mes "[轉蛋機]";
+	mes "結果：";
+	for (.@i = 0; .@i < .@pulls; ++.@i) {
+
+		.@roll = rand(.w_total);
+		.@tier = 0;	// 0=top, 1=mid, 2=low
+
+		if (.@roll < .w_top) {
+			.@tier = 0;
+		} else if (.@roll < .w_top + .w_mid) {
+			.@tier = 1;
+		} else {
+			.@tier = 2;
+		}
+
+		// 10-pull guarantee: force last roll to mid-tier if no rare yet
+		if (.@guaranteed_rare && !.@got_rare && .@i == .@pulls - 1 && .@tier == 2)
+			.@tier = 1;
+
+		if (.@tier <= 1)
+			.@got_rare = 1;
+
+		// Pick a random item from the chosen tier pool
+		if (.@tier == 0) {
+			.@idx = rand(.top_size);
+			.@item_id = .top_items[.@idx];
+			.@qty = .top_qty;
+			.@color$ = "^FF0000";
+		} else if (.@tier == 1) {
+			.@idx = rand(.mid_size);
+			.@item_id = .mid_items[.@idx];
+			.@qty = .mid_qty;
+			.@color$ = "^0055FF";
+		} else {
+			.@idx = rand(.low_size);
+			.@item_id = .low_items[.@idx];
+			.@qty = .low_qty;
+			.@color$ = "^777777";
+		}
+
+		getitem .@item_id, .@qty;
+		mes (.@i + 1) + ". " + .@color$ + getitemname(.@item_id) + " x " + .@qty + "^000000";
+
+		if (.@tier == 0 && .announce_top)
+			announce "[轉蛋] " + strcharinfo(0) + " 抽中了大獎：" + getitemname(.@item_id) + "！", bc_all;
+	}
+	close;
+
+OnInit:
+	// ============== Configuration ==============
+
+	// Cost: set use_item = 1 to charge a ticket item, 0 to charge Zeny.
+	.use_item       = 0;
+	.price          = 10000;		// Zeny per pull (when use_item = 0)
+	.ticket_id      = 7711;			// Ticket item id (when use_item = 1)
+	.ticket_amount  = 1;			// Tickets per pull
+
+	// Announce top-tier wins to the whole server
+	.announce_top   = 1;
+
+	// Prize weights (any positive numbers; ratio is what matters)
+	.w_top = 5;		// 5%  ratio of top weight
+	.w_mid = 20;	// 20% ratio
+	.w_low = 75;	// 75% ratio
+	.w_total = .w_top + .w_mid + .w_low;
+
+	// --- Top tier prizes (rare) ---
+	.top_qty = 1;
+	setarray .top_items[0],
+		617,	// Old Violet Box
+		644,	// Gift Box
+		12103;	// Bloody Branch
+	.top_size = getarraysize(.top_items);
+
+	// --- Mid tier prizes ---
+	.mid_qty = 1;
+	setarray .mid_items[0],
+		603,	// Old Blue Box
+		616,	// Old Card Album
+		12246;	// Mystical Card Album
+	.mid_size = getarraysize(.mid_items);
+
+	// --- Low tier prizes (common) ---
+	.low_qty = 5;
+	setarray .low_items[0],
+		501,	// Red Potion
+		502,	// Orange Potion
+		503,	// Yellow Potion
+		504;	// White Potion
+	.low_size = getarraysize(.low_items);
+
+	end;
+}
+
+// -- Duplicates --
+// Uncomment / add as you wish:
+//morocc,156,93,4	duplicate(Gacha Machine#cgacha)	Gacha Machine#mor	76
+//geffen,120,66,4	duplicate(Gacha Machine#cgacha)	Gacha Machine#gef	76

--- a/npc/scripts_custom.conf
+++ b/npc/scripts_custom.conf
@@ -32,6 +32,8 @@
 //npc: npc/custom/etc/bank.txt
 // -- Lottery (very flexible)
 //npc: npc/custom/etc/lottery.txt
+// -- Custom Gacha (configurable capsule machine)
+//npc: npc/custom/etc/gacha.txt
 // -- Stock Market (Play on it, earn money, very flexible)
 //npc: npc/custom/etc/stock_market.txt
 // -- Russian Roulette + Rock Scissors Paper (warning! contains OBB/OVB/OCA/etc. prizes!)


### PR DESCRIPTION
* **Addressed Issue(s)**: 

N/A - Feature addition

* **Server Mode**: 

Both

* **Description of Pull Request**: 

This pull request adds a new custom gacha (capsule machine) NPC script that provides a configurable prize system for servers. The script includes:

**Features:**
- Flexible payment system supporting either Zeny or custom ticket items
- Three-tier weighted prize system (Top/Mid/Low rarity)
- Single pull or 10-pull mechanics with guaranteed rare item on 10-pull
- Configurable item pools and quantities for each tier
- Optional server-wide announcement when top-tier prizes are won
- Probability display for players
- Support for multiple NPC duplicates via commented examples

**Configuration:**
All aspects are easily configurable in the `OnInit` block:
- Payment method and costs
- Prize weights/probabilities
- Item pools and quantities for each tier
- Announcement settings

The script is disabled by default and can be enabled by uncommenting the line in `npc/scripts_custom.conf`.

**Files Changed:**
- Added `npc/custom/etc/gacha.txt` - Complete gacha NPC implementation with Chinese localization
- Modified `npc/scripts_custom.conf` - Added commented entry to enable the script

https://claude.ai/code/session_011d86M21fPYhhJByUmASgYd