### PR TITLE
chore: scaffold overlay directories for customisation discipline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,10 +64,15 @@ Thumbs.db
 /3rdparty/httplib/obj
 
 # /db/
-/db/import
+/db/import/*
+!/db/import/README.md
+!/db/import/*.yml
 
 # /conf/
-/conf/import
+/conf/import/*
+!/conf/import/README.md
+!/conf/import/*.conf
+!/conf/import/*.txt
 /conf/msg_conf/import
 
 # /lib

--- a/conf/import/README.md
+++ b/conf/import/README.md
@@ -1,0 +1,12 @@
+# conf/import/
+
+rAthena 上游的設定覆蓋點。本目錄的 `*.conf` 會在 `conf/*.conf` 之後被讀取，
+任何 key 在這裡重設都會覆蓋上游預設值，但**不會修改上游檔案本身**。
+
+## 規則
+- 客製設定一律放這裡，**不要直接編輯 `conf/*.conf`**
+- 命名建議：與被覆蓋的上游檔同名（例：`conf/import/battle_conf.txt` 對應 `conf/battle_conf.txt`）
+- UTF-8 **無 BOM**
+
+## 載入順序
+詳見 `conf/import-tmpl/` 與 `conf/*.conf` 末尾的 `import:` 指令。

--- a/data-overlay/README.md
+++ b/data-overlay/README.md
@@ -1,0 +1,18 @@
+# data-overlay/
+
+本專案自建的客戶端資源覆蓋來源（**非 rAthena 上游提供**）。
+
+## 用途
+存放要餵給 client 的 lub / lua / 圖檔來源，最終會被打包進 GRF 或散檔覆蓋。
+
+## 結構
+- `lub/` —— iteminfo / skillinfo / questinfo 等中文化來源（Lua）
+- `grf/` —— 圖檔、texture、bgm 等資源來源
+
+## 編碼規則（重要）
+- `iteminfo.lub` 的 **頂層 Lua 檔本身用 UTF-8**
+- 但 `*ResourceName` 欄位指向的 BMP / SPR 檔名，是**韓文 EUC-KR**，**永不轉碼**
+- 中文顯示走 `*identifiedDisplayName` / `*unidentifiedDisplayName`
+
+## 打包
+打包腳本另立（尚未建立）。本目錄只放來源檔，產出的 `.grf` / `.lub` **不要 commit**。

--- a/db/import/README.md
+++ b/db/import/README.md
@@ -1,0 +1,12 @@
+# db/import/
+
+rAthena 上游 YAML DB 的覆蓋點。本目錄的 YAML 會在 `db/(re|pre-re)/` 之後被讀取，
+同一筆資料（例：`Item_DB`、`Mob_DB`）在這裡重定義就會覆蓋上游版本。
+
+## 規則
+- 中文化、調整數值、新增客製道具/魔物，一律放這裡
+- **不要直接編輯 `db/re/` 或 `db/pre-re/`** —— 會與上游同步衝突
+- 檔名與上游一致（例：`db/import/item_db.yml` 對應 `db/(re|pre-re)/item_db.yml`）
+
+## 載入順序
+詳見 `db/import-tmpl/` 與各 YAML loader 的 `Footer.Imports`。

--- a/sql-files/migrations/README.md
+++ b/sql-files/migrations/README.md
@@ -1,0 +1,20 @@
+# sql-files/migrations/
+
+本專案自建的 schema 變更目錄（**非 rAthena 上游提供**）。
+
+## 用途
+為客製功能（轉蛋、商城、活動等）新增資料表 / 欄位 / 索引，與上游 `sql-files/*.sql` 完全隔離。
+
+## 規則
+- **不要修改上游的 `sql-files/main.sql` / `logs.sql` / `roulette_default_data.sql` 等**
+- 檔名格式：`YYYYMMDD_<feature>.sql`（例：`20260507_gacha_table.sql`）
+- 字元集：`utf8mb4` + `utf8mb4_unicode_ci`
+- 每個檔案應可重複執行（用 `CREATE TABLE IF NOT EXISTS` / `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` 等）
+- 套用順序依檔名排序
+
+## 套用方式
+```bash
+for f in sql-files/migrations/*.sql; do
+  mysql -u <user> -p <db> < "$f"
+done
+```


### PR DESCRIPTION
## Summary
- 建立 overlay 骨架以實踐 CLAUDE.md 的「上游不修改、客製走覆蓋點」原則
- 新增 4 個 overlay 目錄 + 各自 README：`conf/import/`、`db/import/`、`sql-files/migrations/`、`data-overlay/{lub,grf}/`
- 調整 `.gitignore`：`/conf/import` → `/conf/import/*`（同樣處理 `db/import`），加 `!` re-include 規則，讓客製覆蓋進得了 git，但 user-local 雜檔仍被 ignore

## 動機
之前 PR #3（轉蛋功能）把客製 NPC 放在 `npc/custom/`（上游有提供的 import 點），可順利 merge。但專案要長期能 sync 上游，還缺三個自建覆蓋層：
- DB schema 客製：`sql-files/migrations/`（上游 `sql-files/*.sql` 不可碰）
- DB YAML 客製：`db/import/`（上游有提供，但被 gitignore）
- conf 客製：`conf/import/`（同上）
- 客戶端資源：`data-overlay/`（自建）

本 PR 只立骨架 + 文件，不放任何實際覆蓋內容。

## 與上游的隔離
未修改任何 `src/`、`npc/(re|pre-re)/`、`db/(re|pre-re)/`、`sql-files/*.sql`、`conf/*.conf`（除 `conf/import/`）下的檔案。

唯一動到的「上游檔」是 `.gitignore`，僅在原 `/conf/import` 與 `/db/import` 兩行附近做最小調整加 `!` 規則，未來上游若改動 `.gitignore` 衝突面很小。

## Test plan
- [x] `git check-ignore` 確認 `conf/import/README.md` 與 `db/import/README.md` 不再被 ignore
- [x] `git status` 顯示 4 個 README + `.gitignore` 共 5 個檔案變更
- [ ] CI build (PRE/RE) 應通過（純 markdown + gitignore，影響面為零）

https://claude.ai/code/session_011d86M21fPYhhJByUmASgYd

---
_Generated by [Claude Code](https://claude.ai/code/session_011d86M21fPYhhJByUmASgYd)_