### PR TITLE
feat(gacha): add audit log via overlay schema (Phase C)

### DIFF
--- a/npc/custom/etc/gacha.txt
+++ b/npc/custom/etc/gacha.txt
@@ -7,12 +7,15 @@
 //= - Picks a random item from each tier's pool.
 //= - Optional broadcast when a top-tier prize is won.
 //= - Supports single pull or 10-pull (with a small bonus).
+//= - Logs every pull to `gacha_log` for audit.
 //===== How to configure =====================================
-//= 1. Edit the .config block in OnInit below to set the
+//= 1. Apply the schema:
+//      mysql -u <user> -p <db> < sql-files/migrations/20260507_gacha.sql
+//= 2. Edit the .config block in OnInit below to set the
 //    currency, ticket item id, prize pools and weights.
-//= 2. Enable the script in npc/scripts_custom.conf:
+//= 3. Enable the script in npc/scripts_custom.conf:
 //      npc: npc/custom/etc/gacha.txt
-//= 3. Reload with @reloadscript or restart the map-server.
+//= 4. Reload with @reloadscript or restart the map-server.
 //============================================================
 
 prontera,156,180,4	script	Gacha Machine#cgacha	76,{
@@ -105,6 +108,18 @@ prontera,156,180,4	script	Gacha Machine#cgacha	76,{
 
 		getitem .@item_id, .@qty;
 		mes (.@i + 1) + ". " + .@color$ + getitemname(.@item_id) + " x " + .@qty + "^000000";
+
+		// Audit log — schema in sql-files/migrations/20260507_gacha.sql
+		query_sql "INSERT INTO `gacha_log` "
+			+ "(`char_id`,`account_id`,`tier`,`item_id`,`qty`,`cost_zeny`,`cost_item_id`,`cost_item_qty`) VALUES ("
+			+ getcharid(0) + ","
+			+ getcharid(3) + ","
+			+ .@tier + ","
+			+ .@item_id + ","
+			+ .@qty + ","
+			+ ((.use_item)? 0 : .price) + ","
+			+ ((.use_item)? .ticket_id : 0) + ","
+			+ ((.use_item)? .ticket_amount : 0) + ")";
 
 		if (.@tier == 0 && .announce_top)
 			announce "[轉蛋] " + strcharinfo(0) + " 抽中了大獎：" + getitemname(.@item_id) + "！", bc_all;

--- a/npc/custom/etc/gacha.txt
+++ b/npc/custom/etc/gacha.txt
@@ -66,6 +66,10 @@ prontera,156,180,4	script	Gacha Machine#cgacha	76,{
 	.@guaranteed_rare = (.@pulls >= 10)? 1 : 0;
 	.@got_rare = 0;
 
+	// One batch id per gacha_log row group (single pull = 1 row, 10-pull = 10 rows sharing this id)
+	.@batch_id = gettimetick(2) * 10000 + rand(10000);
+	.@values$ = "";
+
 	mes "[轉蛋機]";
 	mes "結果：";
 	for (.@i = 0; .@i < .@pulls; ++.@i) {
@@ -109,11 +113,15 @@ prontera,156,180,4	script	Gacha Machine#cgacha	76,{
 		getitem .@item_id, .@qty;
 		mes (.@i + 1) + ". " + .@color$ + getitemname(.@item_id) + " x " + .@qty + "^000000";
 
-		// Audit log — schema in sql-files/migrations/20260507_gacha.sql
-		query_sql "INSERT INTO `gacha_log` "
-			+ "(`char_id`,`account_id`,`tier`,`item_id`,`qty`,`cost_zeny`,`cost_item_id`,`cost_item_qty`) VALUES ("
+		// Build one VALUES tuple per pull; flushed in a single INSERT after the loop.
+		// All ints come from script vars / config — no injection surface.
+		if (.@values$ != "")
+			.@values$ = .@values$ + ",";
+		.@values$ = .@values$ + "("
 			+ getcharid(0) + ","
 			+ getcharid(3) + ","
+			+ .@batch_id + ","
+			+ (.@i + 1) + ","
 			+ .@tier + ","
 			+ .@item_id + ","
 			+ .@qty + ","
@@ -124,6 +132,12 @@ prontera,156,180,4	script	Gacha Machine#cgacha	76,{
 		if (.@tier == 0 && .announce_top)
 			announce "[轉蛋] " + strcharinfo(0) + " 抽中了大獎：" + getitemname(.@item_id) + "！", bc_all;
 	}
+
+	// Audit log — schema in sql-files/migrations/20260507_gacha.sql
+	query_sql "INSERT INTO `gacha_log` "
+		+ "(`char_id`,`account_id`,`pull_batch_id`,`pull_idx`,`tier`,`item_id`,`qty`,`cost_zeny`,`cost_item_id`,`cost_item_qty`) VALUES "
+		+ .@values$;
+
 	close;
 
 OnInit:

--- a/sql-files/migrations/20260507_gacha.sql
+++ b/sql-files/migrations/20260507_gacha.sql
@@ -1,0 +1,29 @@
+-- ===================================================================
+-- gacha audit log
+-- ===================================================================
+-- 紀錄每次轉蛋的中獎結果，提供：
+--   * 客訴查詢（玩家說沒拿到獎品時對得上時間 / item_id）
+--   * 機率審計（驗證實際中獎分佈與設定的權重相符）
+--   * 防作弊（短時間內大量同 IP / 同帳號的異常拉霸）
+--
+-- Schema 自建，與 rAthena 上游 sql-files/*.sql 完全隔離。
+-- 套用：mysql -u <user> -p <db> < sql-files/migrations/20260507_gacha.sql
+-- ===================================================================
+
+CREATE TABLE IF NOT EXISTS `gacha_log` (
+  `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `char_id`       INT UNSIGNED    NOT NULL,
+  `account_id`    INT UNSIGNED    NOT NULL,
+  `pulled_at`     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `tier`          TINYINT UNSIGNED NOT NULL COMMENT '0=top 1=mid 2=low',
+  `item_id`       INT UNSIGNED    NOT NULL,
+  `qty`           INT UNSIGNED    NOT NULL,
+  `cost_zeny`     INT UNSIGNED    NOT NULL DEFAULT 0,
+  `cost_item_id`  INT UNSIGNED    NOT NULL DEFAULT 0,
+  `cost_item_qty` INT UNSIGNED    NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `idx_char_time` (`char_id`, `pulled_at`),
+  KEY `idx_account_time` (`account_id`, `pulled_at`),
+  KEY `idx_item` (`item_id`),
+  KEY `idx_tier_time` (`tier`, `pulled_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql-files/migrations/20260507_gacha.sql
+++ b/sql-files/migrations/20260507_gacha.sql
@@ -11,19 +11,22 @@
 -- ===================================================================
 
 CREATE TABLE IF NOT EXISTS `gacha_log` (
-  `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `char_id`       INT UNSIGNED    NOT NULL,
-  `account_id`    INT UNSIGNED    NOT NULL,
-  `pulled_at`     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `tier`          TINYINT UNSIGNED NOT NULL COMMENT '0=top 1=mid 2=low',
-  `item_id`       INT UNSIGNED    NOT NULL,
-  `qty`           INT UNSIGNED    NOT NULL,
-  `cost_zeny`     INT UNSIGNED    NOT NULL DEFAULT 0,
-  `cost_item_id`  INT UNSIGNED    NOT NULL DEFAULT 0,
-  `cost_item_qty` INT UNSIGNED    NOT NULL DEFAULT 0,
+  `id`             BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `char_id`        INT UNSIGNED    NOT NULL,
+  `account_id`     INT UNSIGNED    NOT NULL,
+  `pulled_at`      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `pull_batch_id`  BIGINT UNSIGNED NOT NULL COMMENT '同次抽獎共用 (1抽=1筆, 10連=10筆共用)',
+  `pull_idx`       TINYINT UNSIGNED NOT NULL COMMENT '1..N within batch',
+  `tier`           TINYINT UNSIGNED NOT NULL COMMENT '0=top 1=mid 2=low',
+  `item_id`        INT UNSIGNED    NOT NULL,
+  `qty`            INT UNSIGNED    NOT NULL,
+  `cost_zeny`      INT UNSIGNED    NOT NULL DEFAULT 0,
+  `cost_item_id`   INT UNSIGNED    NOT NULL DEFAULT 0,
+  `cost_item_qty`  INT UNSIGNED    NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `idx_char_time` (`char_id`, `pulled_at`),
   KEY `idx_account_time` (`account_id`, `pulled_at`),
   KEY `idx_item` (`item_id`),
-  KEY `idx_tier_time` (`tier`, `pulled_at`)
+  KEY `idx_tier_time` (`tier`, `pulled_at`),
+  KEY `idx_batch` (`pull_batch_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- 為轉蛋 NPC 加上抽獎稽核紀錄
- **示範前兩個 PR 建立的 overlay 紀律**：新 schema 走 `sql-files/migrations/`，NPC 用 `query_sql` 寫入，**沒有改動任何上游檔案**

## 變更
- `sql-files/migrations/20260507_gacha.sql` —— 新增 `gacha_log` table
- `npc/custom/etc/gacha.txt` —— 每次抽獎後寫一筆紀錄（tier、item_id、qty、cost）；header 加上套用 schema 的步驟

## Schema 用途
`gacha_log` 紀錄欄位：char_id、account_id、pulled_at、tier、item_id、qty、cost_zeny、cost_item_id、cost_item_qty。
索引涵蓋三類查詢：
- 客訴查詢：`(char_id, pulled_at)`
- 異常偵測：`(account_id, pulled_at)`、`(tier, pulled_at)`
- 機率審計：`(item_id)`

## 與上游的隔離
- 沒碰 `sql-files/*.sql`（上游 schema）
- 沒碰 `db/(re|pre-re)/`、`npc/(re|pre-re)/`、`src/`
- 唯一動到的「上游有提供的 import 點」是 `npc/custom/etc/gacha.txt`，這在前一個 PR 已經放了

## 套用步驟（給 operator）
```bash
mysql -u <user> -p <db> < sql-files/migrations/20260507_gacha.sql
@reloadscript  # 或重啟 map-server
```

## Test plan
- [x] script 語法目測（query_sql 字串拼接、純整數變數，無 SQL injection 風險）
- [ ] CI build PRE/RE 通過
- [ ] （手動）實際抽一次，`SELECT * FROM gacha_log ORDER BY id DESC LIMIT 1;` 對得上

https://claude.ai/code/session_011d86M21fPYhhJByUmASgYd

---
_Generated by [Claude Code](https://claude.ai/code/session_011d86M21fPYhhJByUmASgYd)_